### PR TITLE
slightly changed group member deletion approach

### DIFF
--- a/api_address_group.go
+++ b/api_address_group.go
@@ -368,17 +368,19 @@ func (a *AddressGroupAPIService) RemoveMemberExecute(r ApiRemoveMemberRequest) (
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/address/groups/{groupAddress}"
-	localVarPath = strings.Replace(localVarPath, "{"+"groupAddress"+"}", url.PathEscape(parameterValueToString(r.groupAddress, "groupAddress")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
 	if r.memberAddress == nil {
 		return nil, reportError("memberAddress is required and must be specified")
 	}
 
-	parameterAddToHeaderOrQuery(localVarQueryParams, "memberAddress", r.memberAddress, "")
+	localVarPath := localBasePath + "/address/groups/{groupAddress}"
+	localVarPath = strings.Replace(localVarPath, "{"+"groupAddress"+"}", url.PathEscape(parameterValueToString(r.groupAddress, "groupAddress")), -1) + "/" + *r.memberAddress
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+
+	//parameterAddToHeaderOrQuery(localVarQueryParams, "memberAddress", r.memberAddress, "")
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 


### PR DESCRIPTION
the group member to be deleted has been moved to the url path instead of url parameter, following the [james webadmin api.](https://james.apache.org/server/manage-webadmin.html#Creating_address_group) 
