### PR TITLE
Add "Connection: close" header, fixing eclipse.jetty.io.EofException

### DIFF
--- a/client.go
+++ b/client.go
@@ -329,6 +329,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		log.Printf("\n%s\n", string(dump))
 	}
 
+	request.Header.Set("Connection", "close")
+
 	resp, err := c.cfg.HTTPClient.Do(request)
 	if err != nil {
 		return resp, err


### PR DESCRIPTION
```
2025/02/19 06:38:30 ...uster/inbox/agent.go:32:GetInboxAgentToken() [I] Inbox Service: User `appscode` requested an agent token for cluster `ace` (UID: `48f66dd4-9ef4-4222-8b02-27283c083cad`)
[Macaron] 2025-02-19 06:38:30: Completed GET /api/v1/agent/ace/48f66dd4-9ef4-4222-8b02-27283c083cad/token 500 Internal Server Error in 38.315217ms
2025/02/19 06:38:30 ...les/setting/inbox.go:55:GetInboxService() [E] couldn't connect to inbox server: org.eclipse.jetty.io.EofException: Closed
2025/02/19 06:38:30 ...dules/context/api.go:69:Error() [E] : could not get inbox service
[Macaron] 2025-02-19 06:38:33: Started GET /api/v1/agent/ace/48f66dd4-9ef4-4222-8b02-27283c083cad/token for 10.42.0.1
2025/02/19 06:38:33 ...uster/inbox/agent.go:32:GetInboxAgentToken() [I] Inbox Service: User `appscode` requested an agent token for cluster `ace` (UID: `48f66dd4-9ef4-4222-8b02-27283c083cad`)
2025/02/19 06:38:33 ...les/setting/inbox.go:55:GetInboxService() [E] couldn't connect to inbox server: org.eclipse.jetty.io.EofException: Closed
```

[b3/james-integ-rewrite](https://github.com/appscode-cloud/b3/tree/james-integ-rewrite) fails to communicate with [ops-center/opscenter-cherrypick](https://github.com/ops-center/james-project/tree/opscenter-cherrypick) and logs the error above unless the "Connection: close" header is set. 
The same error can be observed if Postman queries are made to the webadmin api without setting this header.