### PR TITLE
Remove "Connection: close" header.

### DIFF
--- a/client.go
+++ b/client.go
@@ -329,8 +329,6 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		log.Printf("\n%s\n", string(dump))
 	}
 
-	request.Header.Set("Connection", "close")
-
 	resp, err := c.cfg.HTTPClient.Do(request)
 	if err != nil {
 		return resp, err


### PR DESCRIPTION
This header is no longer necessary as a fix has been [merged](https://github.com/apache/james-project/pull/2655) into apache/james@master, so that James automatically adds this header to all WebAdmin responses.