### PR TITLE
Add 1gtm-app[bot] to kodiak auto_approve_usernames

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha"]
+auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]

--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]
+auto_approve_usernames = ["tamalsaha", "1gtm", "1gtm-app[bot]"]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CODE_GENERATOR_IMAGE ?= ghcr.io/appscode/gengo:release-1.29
 
 # This version-strategy uses git tags to set the version string
 git_branch       := $(shell git rev-parse --abbrev-ref HEAD)
-git_tag          := $(shell git describe --exact-match --abbrev=0 2>/dev/null || echo "")
+git_tag          := $(shell git describe --tags --exact-match --abbrev=0 2>/dev/null || echo "")
 commit_hash      := $(shell git rev-parse --verify HEAD)
 commit_timestamp := $(shell date --date="@$$(git show -s --format=%ct)" --utc +%FT%T)
 


### PR DESCRIPTION
Allow the LGTM GitHub App to act as approver in kodiak.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/james-go-client/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->