### PR TITLE
Add 'DeepCopyObject' to meet kubebuilder requirements

### DIFF
--- a/inbox/helpers.go
+++ b/inbox/helpers.go
@@ -36,7 +36,7 @@ func GenerateBaseAddress(object Object) (string, error) {
 		return "", errors.New("nil object reference")
 	}
 
-	if val := reflect.ValueOf(object); val.Kind() == reflect.Ptr && val.IsNil() {
+	if val := reflect.ValueOf(object); val.Kind() == reflect.Pointer && val.IsNil() {
 		return "", errors.New("nil object pointer")
 	}
 
@@ -63,7 +63,7 @@ func GetObjectIdentifierFromObjectInterface(object Object) (*ObjectIdentifier, e
 }
 
 func getObjectIdentifierFromObjectInterface(object Object) (*ObjectIdentifier, error) {
-	if object == nil || (reflect.ValueOf(object).Kind() == reflect.Ptr && reflect.ValueOf(object).IsNil()) {
+	if object == nil || (reflect.ValueOf(object).Kind() == reflect.Pointer && reflect.ValueOf(object).IsNil()) {
 		return nil, nil
 	}
 
@@ -92,7 +92,7 @@ func getObjectIdentifierFromObjectInterface(object Object) (*ObjectIdentifier, e
 }
 
 func GetGroupAndAssociatedMemberIdentifier(object Object) ([]GroupAndAssociatedMemberIdentifier, error) {
-	if object == nil || (reflect.ValueOf(object).Kind() == reflect.Ptr && reflect.ValueOf(object).IsNil()) {
+	if object == nil || (reflect.ValueOf(object).Kind() == reflect.Pointer && reflect.ValueOf(object).IsNil()) {
 		return nil, nil
 	}
 

--- a/inbox/types.go
+++ b/inbox/types.go
@@ -218,6 +218,7 @@ type Object interface {
 	// means of addressing the object, typically used for email forwarding, nicknames, or
 	// alternate contact points.
 	GetAddressAlias() (string, error)
+	DeepCopyObject() Object
 }
 
 type ObjectIdentifier struct {
@@ -286,6 +287,10 @@ func (o *ObjectIdentifier) DeepCopy() *ObjectIdentifier {
 		out.ParentObject = o.ParentObject.DeepCopy()
 	}
 	return out
+}
+
+func (o ObjectIdentifier) DeepCopyObject() Object {
+	return o.DeepCopy()
 }
 
 type UserIdentity struct {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/james-go-client/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784365517&installation_id=126731068&pr_number=56&repository=opnpulse%2Fjames-go-client&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Fjames-go-client%2Fpull%2F56&signature=624259f5f954cac819fb06f5f7f2c98f1b7a852ab4aaf3d4fd0455d47dc08b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->